### PR TITLE
fix: the runtime_malloc() function accepts a signed ... in...

### DIFF
--- a/runtime/zenith_runtime.c
+++ b/runtime/zenith_runtime.c
@@ -64,7 +64,7 @@ static const uint32_t CRC32C_TABLE[256] = {
 
 /* ───── Existing Zeta runtime functions ───── */
 
-void* runtime_malloc(long size) { return malloc((size_t)size); }
+void* runtime_malloc(long size) { if (size <= 0) return NULL; return malloc((size_t)size); }
 void runtime_free(void* ptr) { free(ptr); }
 
 void println_i64(long val) { printf("%ld\n", val); }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `runtime/zenith_runtime.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `runtime/zenith_runtime.c:67` |

**Description**: The runtime_malloc() function accepts a signed 'long' size parameter and casts it directly to size_t before passing to malloc(). A negative value such as -1 cast to size_t becomes SIZE_MAX (0xFFFFFFFFFFFFFFFF on 64-bit systems), causing malloc to attempt an enormous allocation and return NULL. The NULL return value is never checked, so any caller that dereferences the returned pointer will crash or trigger undefined behavior. A crafted small-negative value (e.g., -65528) casts to a small size_t (e.g., 8), producing an undersized allocation that is subsequently overflowed by writes of the expected larger size, enabling heap metadata corruption.

## Changes
- `runtime/zenith_runtime.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
