### PR TITLE
LLVM 21 → 22: build stack upgrade + codegen/runtime fixes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -52,19 +52,18 @@ jobs:
       llvm_prefix: ${{ steps.set-llvm.outputs.llvm_prefix }}
     steps:
     - uses: actions/checkout@v4
-    - name: Install LLVM 21
+    - name: Install LLVM 22
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 21
+        sudo ./llvm.sh 22
         sudo apt-get update
-        sudo apt-get install -y llvm-21 llvm-21-dev llvm-21-tools libpolly-21-dev
+        sudo apt-get install -y llvm-22 llvm-22-dev llvm-22-tools libpolly-22-dev
     - name: Set LLVM prefix
       id: set-llvm
       run: |
-        echo "LLVM_SYS_210_PREFIX=/usr/lib/llvm-21" >> $GITHUB_ENV
-        echo "LLVM_SYS_211_PREFIX=/usr/lib/llvm-21" >> $GITHUB_ENV
-        echo "llvm_prefix=/usr/lib/llvm-21" >> $GITHUB_OUTPUT
+        echo "LLVM_SYS_221_PREFIX=/usr/lib/llvm-22" >> $GITHUB_ENV
+        echo "llvm_prefix=/usr/lib/llvm-22" >> $GITHUB_OUTPUT
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
@@ -88,8 +87,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup LLVM
       run: |
-        echo "LLVM_SYS_210_PREFIX=${{ needs.setup.outputs.llvm_prefix }}" >> $GITHUB_ENV
-        echo "LLVM_SYS_211_PREFIX=${{ needs.setup.outputs.llvm_prefix }}" >> $GITHUB_ENV
+        echo "LLVM_SYS_221_PREFIX=${{ needs.setup.outputs.llvm_prefix }}" >> $GITHUB_ENV
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
@@ -130,8 +128,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup LLVM
       run: |
-        echo "LLVM_SYS_210_PREFIX=${{ needs.setup.outputs.llvm_prefix }}" >> $GITHUB_ENV
-        echo "LLVM_SYS_211_PREFIX=${{ needs.setup.outputs.llvm_prefix }}" >> $GITHUB_ENV
+        echo "LLVM_SYS_221_PREFIX=${{ needs.setup.outputs.llvm_prefix }}" >> $GITHUB_ENV
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
@@ -172,8 +169,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup LLVM
       run: |
-        echo "LLVM_SYS_210_PREFIX=${{ needs.setup.outputs.llvm_prefix }}" >> $GITHUB_ENV
-        echo "LLVM_SYS_211_PREFIX=${{ needs.setup.outputs.llvm_prefix }}" >> $GITHUB_ENV
+        echo "LLVM_SYS_221_PREFIX=${{ needs.setup.outputs.llvm_prefix }}" >> $GITHUB_ENV
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"
-  LLVM_SYS_210_PREFIX: /usr/lib/llvm-21
-  LLVM_SYS_211_PREFIX: /usr/lib/llvm-21
+  LLVM_SYS_221_PREFIX: /usr/lib/llvm-22
 
 jobs:
   check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  LLVM_SYS_210_PREFIX: /usr/lib/llvm-21
-  LLVM_SYS_211_PREFIX: /usr/lib/llvm-21
+  LLVM_SYS_221_PREFIX: /usr/lib/llvm-22
 
 jobs:
   build-linux:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,22 +2361,22 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1def4112dfb2ce2993db7027f7acdb43c1f4ee1c70a082a2eef306ed5d0df365"
+checksum = "7decbc9dfa45a4a827a6ff7b822c113b1285678a937e84213417d4ca8a095782"
 dependencies = [
+ "bitflags 2.11.1",
  "inkwell_internals",
  "libc",
  "llvm-sys",
- "once_cell",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "inkwell_internals"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63736175c9a30ea123f7018de9f26163e0b39cd6978990ae486b510c4f3bad69"
+checksum = "6cfe97ee860815a90ed17e09639513269e39420a7440f3f4c996f238c514cf8d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2672,9 +2672,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llvm-sys"
-version = "211.0.1"
+version = "221.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44007a7a44b73bdd877fa9c9ccef256036511220e90f65b4d50e7a15773c0ee3"
+checksum = "2abcc34a3b190f03c2a61b555f218f529589ff13657bdd2ff8ac3e85f2abe6bb"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ chrono = { version = "0.4.43", features = ["serde"] }
 # Sum type for two variants.
 either = "1.15.0"
 # LLVM bindings.
-inkwell = { version = "0.8.0", features = ["llvm21-1"] }
-llvm-sys = { version = "211.0.0", features = ["prefer-dynamic"] }
+inkwell = { version = "0.9.0", features = ["llvm22-1"] }
+llvm-sys = { version = "221.0.0", features = ["prefer-dynamic"] }
 # Lazy static initialization.
 lazy_static = "1.5.0"
 # C library interfaces.

--- a/src/backend/codegen/codegen.rs
+++ b/src/backend/codegen/codegen.rs
@@ -372,20 +372,14 @@ impl<'ctx> LLVMCodegen<'ctx> {
             Some(Linkage::External),
         );
         let mem_attr = context.create_string_attribute("memory", "unknown");
-        malloc_func.add_attribute(
-            inkwell::attributes::AttributeLoc::Function,
-            mem_attr,
-        );
+        malloc_func.add_attribute(inkwell::attributes::AttributeLoc::Function, mem_attr);
         let free_func = module.add_function(
             "runtime_free",
             void_type.fn_type(&[i64_type.into()], false),
             Some(Linkage::External),
         );
         let mem_attr2 = context.create_string_attribute("memory", "unknown");
-        free_func.add_attribute(
-            inkwell::attributes::AttributeLoc::Function,
-            mem_attr2,
-        );
+        free_func.add_attribute(inkwell::attributes::AttributeLoc::Function, mem_attr2);
         module.add_function(
             "runtime_calloc",
             i64_type.fn_type(&[i64_type.into(), i64_type.into()], false),
@@ -397,9 +391,14 @@ impl<'ctx> LLVMCodegen<'ctx> {
             Some(Linkage::External),
         );
         // Array functions
+        // NOTE: signatures must match the runtime impls in src/runtime/array.rs
+        // exactly (array_new takes ONE capacity arg). A mismatched re-declaration
+        // makes LLVM create a numbered duplicate (array_new.10) that call sites
+        // bind to and that the JIT mapping table cannot resolve (NULL -> segfault).
+        // Declare each runtime symbol exactly once.
         module.add_function(
             "array_new",
-            i64_type.fn_type(&[i64_type.into(), i64_type.into()], false),
+            i64_type.fn_type(&[i64_type.into()], false),
             Some(Linkage::External),
         );
         module.add_function(
@@ -434,7 +433,7 @@ impl<'ctx> LLVMCodegen<'ctx> {
         );
         module.add_function(
             "array_push",
-            i64_type.fn_type(&[i64_type.into(), i64_type.into()], false),
+            void_type.fn_type(&[i64_type.into(), i64_type.into()], false),
             Some(Linkage::External),
         );
         module.add_function(
@@ -657,58 +656,11 @@ impl<'ctx> LLVMCodegen<'ctx> {
             );
         }
 
-        // Array runtime functions
-        // Note: array_new already declared above (line 312)
-        // module.add_function(
-        //     "array_new",
-        //     i64_type.fn_type(&[i64_type.into()], false),
-        //     Some(Linkage::External),
-        // );
-        module.add_function(
-            "array_push",
-            void_type.fn_type(&[i64_type.into(), i64_type.into()], false),
-            Some(Linkage::External),
-        );
-        module.add_function(
-            "array_len",
-            i64_type.fn_type(&[i64_type.into()], false),
-            Some(Linkage::External),
-        );
-        let array_get_fn2 = module.add_function(
-            "array_get",
-            i64_type.fn_type(&[i64_type.into(), i64_type.into()], false),
-            Some(Linkage::External),
-        );
-        #[cfg(target_os = "windows")]
-        {
-            // Note: Calling convention setting disabled - can't find correct API in inkwell 0.8.0
-            // array_get_fn2.set_call_conventions(...);
-        }
-        module.add_function(
-            "stack_array_get",
-            i64_type.fn_type(&[i64_type.into(), i64_type.into()], false),
-            Some(Linkage::External),
-        );
-        module.add_function(
-            "array_set",
-            void_type.fn_type(&[i64_type.into(), i64_type.into(), i64_type.into()], false),
-            Some(Linkage::External),
-        );
-        module.add_function(
-            "stack_array_set",
-            void_type.fn_type(&[i64_type.into(), i64_type.into(), i64_type.into()], false),
-            Some(Linkage::External),
-        );
-        module.add_function(
-            "array_free",
-            void_type.fn_type(&[i64_type.into()], false),
-            Some(Linkage::External),
-        );
-        module.add_function(
-            "array_set_len",
-            void_type.fn_type(&[i64_type.into(), i64_type.into()], false),
-            Some(Linkage::External),
-        );
+        // Array runtime functions (array_new/push/len/get/set/free/set_len, stack_*)
+        // are all declared once in the block above — do NOT re-declare them here:
+        // LLVM uniquing turns same-name re-declarations into numbered duplicates
+        // (array_push.1, ...), which call sites can bind to and which the JIT
+        // mapping table cannot resolve (NULL -> segfault).
         module.add_function(
             "scheduler::init_runtime",
             void_type.fn_type(&[], false),
@@ -755,14 +707,9 @@ impl<'ctx> LLVMCodegen<'ctx> {
         // === PRINTLN SUPPORT (the fix) ===
         let printf_type = context.i32_type().fn_type(&[ptr_type.into()], true); // variadic
         module.add_function("printf", printf_type, Some(Linkage::External));
-        // println is NOT declared here — the println! macro goes to
-        // println_i64, and user-declared extern fn println(msg: i64) provides
-        // its own declaration.
-        module.add_function(
-            "println_i64",
-            i64_type.fn_type(&[i64_type.into()], false), // takes i64, returns void
-            Some(Linkage::External),
-        );
+        // println_i64 is declared once above (void return, matching the runtime).
+        // Do NOT re-declare it: a second declaration creates a numbered duplicate
+        // (println_i64.N) that the JIT cannot map.
 
         // Zeta runtime functions (temporary bridge)
         module.add_function(
@@ -1416,7 +1363,10 @@ impl<'ctx> LLVMCodegen<'ctx> {
                     self.collect_ids_from_expr_safe(e, ids, exprs);
                 }
             }
-            MirExpr::ConstEval(_) | MirExpr::StringLit(_) | MirExpr::Lit(_) | MirExpr::Syscall(_, _) => {
+            MirExpr::ConstEval(_)
+            | MirExpr::StringLit(_)
+            | MirExpr::Lit(_)
+            | MirExpr::Syscall(_, _) => {
                 // No IDs to collect
             }
         }
@@ -1801,6 +1751,13 @@ impl<'ctx> LLVMCodegen<'ctx> {
             if let Some(f) = self.module.get_function(&host_name) {
                 return f;
             }
+            // Overload-suffixed name (e.g. str_trim_1): retry with the suffix
+            // stripped, else the call falls through to a fresh unmapped extern.
+            if let Some(stripped) = Self::host_candidate_for(name) {
+                if let Some(f) = self.module.get_function(&stripped) {
+                    return f;
+                }
+            }
         }
 
         // Check if it's an external function declared in the module
@@ -1901,6 +1858,25 @@ impl<'ctx> LLVMCodegen<'ctx> {
         f
     }
 
+    /// Map a runtime method name (possibly with a trailing `_N` overload suffix,
+    /// possibly a mangled `{method}_{type_suffix}` form) to its `host_*` std
+    /// counterpart: `str_trim` → `host_str_trim`, `str_trim_1` → `host_str_trim`,
+    /// `len_str_2` → `host_str_len`. Returns None for non-string runtime names.
+    fn host_candidate_for(name: &str) -> Option<String> {
+        // Strip a trailing _N overload suffix before mapping so suffixed calls
+        // (str_trim_1) resolve to the host symbol instead of a junk name.
+        let base = name
+            .rsplit_once('_')
+            .filter(|(_, s)| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()))
+            .map(|(p, _)| p)
+            .unwrap_or(name);
+        if base.starts_with("str_") {
+            Some(format!("host_{base}"))
+        } else {
+            Self::resolve_string_method(base).map(|resolved| format!("host_{resolved}"))
+        }
+    }
+
     /// Map method call mangled names (e.g. `len_str`) back to runtime function names (`str_len`).
     /// Method calls on strings produce "{method}_{type_suffix}" via MonoKey::mangle.
     fn resolve_string_method(name: &str) -> Option<String> {
@@ -1947,13 +1923,7 @@ impl<'ctx> LLVMCodegen<'ctx> {
         // Try existing lookup first — check mangled name (:: → __) BEFORE raw name.
         // gen_mirs stores functions with __, call sites reference with ::.
         // Also handle str_* → host_str_* mapping (string runtime functions).
-        let host_mapped_name = if name.starts_with("str_") {
-            format!("host_{}", name)
-        } else if let Some(resolved) = Self::resolve_string_method(name) {
-            format!("host_{}", resolved)
-        } else {
-            String::new()
-        };
+        let host_mapped_name = Self::host_candidate_for(name).unwrap_or_default();
 
         if type_args.is_empty() {
             // Check mangled name first (AstNode::Lit → AstNode__Lit)
@@ -3222,14 +3192,10 @@ impl<'ctx> LLVMCodegen<'ctx> {
                         while all_args.len() < 7 {
                             all_args.push(self.i64_type.const_zero().into());
                         }
-                        let fn_type = self.i64_type.fn_type(
-                            &[self.i64_type.into(); 7],
-                            false,
-                        );
-                        let callee = self.module.add_function(
-                            "zenith_syscall", fn_type, None,
-                        );
-                        let call = self.builder
+                        let fn_type = self.i64_type.fn_type(&[self.i64_type.into(); 7], false);
+                        let callee = self.module.add_function("zenith_syscall", fn_type, None);
+                        let call = self
+                            .builder
                             .build_call(callee, &all_args, "syscall")
                             .unwrap();
                         let basic_val = Self::call_site_to_basic_value(call)
@@ -3264,7 +3230,10 @@ impl<'ctx> LLVMCodegen<'ctx> {
                             .builder
                             .build_int_to_ptr(addr, self.ptr_type, "load_ptr")
                             .unwrap();
-                        let val = self.builder.build_load(self.i64_type, ptr, "loaded").unwrap();
+                        let val = self
+                            .builder
+                            .build_load(self.i64_type, ptr, "loaded")
+                            .unwrap();
                         let alloca = *self.locals.get(dest).unwrap();
                         self.builder.build_store(alloca, val).unwrap();
                         return;
@@ -3357,12 +3326,12 @@ impl<'ctx> LLVMCodegen<'ctx> {
                     while all_args.len() < 7 {
                         all_args.push(self.i64_type.const_zero().into());
                     }
-                    let fn_type = self.i64_type.fn_type(
-                        &[self.i64_type.into(); 7],
-                        false,
-                    );
+                    let fn_type = self.i64_type.fn_type(&[self.i64_type.into(); 7], false);
                     let callee = self.module.add_function("zenith_syscall", fn_type, None);
-                    let _ = self.builder.build_call(callee, &all_args, "syscall").unwrap();
+                    let _ = self
+                        .builder
+                        .build_call(callee, &all_args, "syscall")
+                        .unwrap();
                     return;
                 }
 
@@ -4139,9 +4108,16 @@ impl<'ctx> LLVMCodegen<'ctx> {
                 // *addr = val — store val through the pointer
                 let addr_i64 = self.gen_expr_safe(addr_id, exprs).into_int_value();
                 let val = self.gen_expr_safe(val_id, exprs);
-                let pointee_llvm_type = self
-                    .context
-                    .custom_width_int_type((*pointee_width as u32) * 8);
+                // inkwell 0.9: custom_width_int_type takes NonZero<u32> and returns a
+                // Result. A zero pointee width falls back to i8.
+                let pointee_llvm_type =
+                    match std::num::NonZero::new((*pointee_width as u32).saturating_mul(8)) {
+                        Some(bits) => self
+                            .context
+                            .custom_width_int_type(bits)
+                            .expect("invalid pointee width in Store"),
+                        None => self.context.i8_type(),
+                    };
                 let pointed_ptr_type: inkwell::types::PointerType =
                     self.context.ptr_type(inkwell::AddressSpace::default());
                 let ptr = self
@@ -4167,18 +4143,13 @@ impl<'ctx> LLVMCodegen<'ctx> {
                 dest,
             } => {
                 // Allocate struct on HEAP to prevent dangling pointers
-                let total_bytes = self.i64_type.const_int(
-                    (fields.len() as u64) * 8,
-                    false,
-                );
+                let total_bytes = self.i64_type.const_int((fields.len() as u64) * 8, false);
                 let malloc_fn = self
                     .module
                     .get_function("runtime_malloc")
                     .unwrap_or_else(|| {
-                        let fn_type =
-                            self.i64_type.fn_type(&[self.i64_type.into()], false);
-                        self.module
-                            .add_function("runtime_malloc", fn_type, None)
+                        let fn_type = self.i64_type.fn_type(&[self.i64_type.into()], false);
+                        self.module.add_function("runtime_malloc", fn_type, None)
                     });
                 let heap_ptr = self
                     .builder
@@ -4196,25 +4167,20 @@ impl<'ctx> LLVMCodegen<'ctx> {
                     .unwrap();
                 for (i, (field_name, field_id)) in fields.iter().enumerate() {
                     let field_ptr = unsafe {
-                        self
-                        .builder
-                        .build_gep(
-                            self.i64_type,
-                            struct_base,
-                            &[self.i64_type.const_int(i as u64, false)],
-                            "field_ptr",
-                        )
-                        .unwrap()
+                        self.builder
+                            .build_gep(
+                                self.i64_type,
+                                struct_base,
+                                &[self.i64_type.const_int(i as u64, false)],
+                                "field_ptr",
+                            )
+                            .unwrap()
                     };
-                    let field_val = self
-                        .gen_expr_safe(field_id, exprs)
-                        .into_int_value();
+                    let field_val = self.gen_expr_safe(field_id, exprs).into_int_value();
                     self.builder.build_store(field_ptr, field_val).unwrap();
                 }
                 let dest_alloca = *self.locals.get(dest).unwrap();
-                self.builder
-                    .build_store(dest_alloca, heap_ptr_val)
-                    .unwrap();
+                self.builder.build_store(dest_alloca, heap_ptr_val).unwrap();
             }
             _ => {}
         }
@@ -4364,25 +4330,29 @@ impl<'ctx> LLVMCodegen<'ctx> {
                 let num_val = self.gen_expr(&exprs[num_id], exprs, None).into_int_value();
                 let mut all_args: Vec<BasicMetadataValueEnum> = vec![num_val.into()];
                 for arg_id in arg_ids {
-                    let val = self.gen_expr(exprs.get(arg_id).unwrap(), exprs, None).into_int_value();
+                    let val = self
+                        .gen_expr(exprs.get(arg_id).unwrap(), exprs, None)
+                        .into_int_value();
                     all_args.push(val.into());
-                    if all_args.len() >= 7 { break; } // 7 = number + 6 args
+                    if all_args.len() >= 7 {
+                        break;
+                    } // 7 = number + 6 args
                 }
                 // Pad to 7 args (number + 6 zero args for unused)
                 while all_args.len() < 7 {
                     all_args.push(self.i64_type.const_zero().into());
                 }
-                
+
                 // Find or declare the C syscall wrapper (use get_function to avoid duplicate .N suffixes)
-                let fn_type = self.i64_type.fn_type(
-                    &[self.i64_type.into(); 7],
-                    false,
-                );
+                let fn_type = self.i64_type.fn_type(&[self.i64_type.into(); 7], false);
                 let callee = match self.module.get_function("zenith_syscall") {
                     Some(f) => f,
                     None => self.module.add_function("zenith_syscall", fn_type, None),
                 };
-                let call = self.builder.build_call(callee, &all_args, "syscall").unwrap();
+                let call = self
+                    .builder
+                    .build_call(callee, &all_args, "syscall")
+                    .unwrap();
                 // CallSiteValue -> BasicValueEnum via try_as_basic_value()
                 match call.try_as_basic_value() {
                     inkwell::values::ValueKind::Basic(val) => val,
@@ -4551,10 +4521,7 @@ impl<'ctx> LLVMCodegen<'ctx> {
                                 "right_bool",
                             )
                             .unwrap();
-                        let bool_or = self
-                            .builder
-                            .build_or(left_bool, right_bool, "or")
-                            .unwrap();
+                        let bool_or = self.builder.build_or(left_bool, right_bool, "or").unwrap();
                         self.builder
                             .build_int_z_extend(bool_or, self.i64_type, "or_ext")
                             .unwrap()
@@ -4567,18 +4534,13 @@ impl<'ctx> LLVMCodegen<'ctx> {
             }
             MirExpr::Struct { variant, fields } => {
                 // Allocate struct on HEAP to prevent dangling pointers
-                let total_bytes = self.i64_type.const_int(
-                    (fields.len() as u64) * 8,
-                    false,
-                );
+                let total_bytes = self.i64_type.const_int((fields.len() as u64) * 8, false);
                 let malloc_fn = self
                     .module
                     .get_function("runtime_malloc")
                     .unwrap_or_else(|| {
-                        let fn_type =
-                            self.i64_type.fn_type(&[self.i64_type.into()], false);
-                        self.module
-                            .add_function("runtime_malloc", fn_type, None)
+                        let fn_type = self.i64_type.fn_type(&[self.i64_type.into()], false);
+                        self.module.add_function("runtime_malloc", fn_type, None)
                     });
                 let heap_ptr = self
                     .builder
@@ -4596,15 +4558,14 @@ impl<'ctx> LLVMCodegen<'ctx> {
                     .unwrap();
                 for (i, (field_name, field_id)) in fields.iter().enumerate() {
                     let field_ptr = unsafe {
-                        self
-                        .builder
-                        .build_gep(
-                            self.i64_type,
-                            struct_base,
-                            &[self.i64_type.const_int(i as u64, false)],
-                            "field_ptr",
-                        )
-                        .unwrap()
+                        self.builder
+                            .build_gep(
+                                self.i64_type,
+                                struct_base,
+                                &[self.i64_type.const_int(i as u64, false)],
+                                "field_ptr",
+                            )
+                            .unwrap()
                     };
                     let field_val = self
                         .gen_expr(&exprs[field_id], exprs, None)
@@ -4878,9 +4839,16 @@ impl<'ctx> LLVMCodegen<'ctx> {
             } => {
                 // *ptr — load through pointer with given element width
                 let ptr_as_i64 = self.gen_expr_safe(addr_id, exprs).into_int_value();
-                let pointee_llvm_type = self
-                    .context
-                    .custom_width_int_type((*pointee_width as u32) * 8);
+                // inkwell 0.9: custom_width_int_type takes NonZero<u32> and returns a
+                // Result. A zero pointee width falls back to i8.
+                let pointee_llvm_type =
+                    match std::num::NonZero::new((*pointee_width as u32).saturating_mul(8)) {
+                        Some(bits) => self
+                            .context
+                            .custom_width_int_type(bits)
+                            .expect("invalid pointee width in Deref"),
+                        None => self.context.i8_type(),
+                    };
                 let pointed_ptr_type = self.context.ptr_type(inkwell::AddressSpace::default());
                 let ptr = self
                     .builder

--- a/src/backend/codegen/jit.rs
+++ b/src/backend/codegen/jit.rs
@@ -17,6 +17,8 @@ use crate::runtime::host::{
     host_str_replace, host_str_starts_with, host_str_to_lowercase, host_str_to_uppercase,
     host_str_trim, host_tls_handshake,
 };
+// Waker host functions (Linux-only: the reactor module is cfg-gated to Linux).
+#[cfg(target_os = "linux")]
 use crate::runtime::reactor::{waker_create, waker_wake};
 use crate::runtime::std::std_free;
 use crate::runtime::zeta_runtime::{
@@ -25,7 +27,6 @@ use crate::runtime::zeta_runtime::{
 };
 use inkwell::OptimizationLevel;
 use inkwell::execution_engine::ExecutionEngine;
-use inkwell::passes::PassManager;
 use inkwell::targets::{FileType, InitializationConfig, Target, TargetMachine, TargetTriple};
 use std::error::Error;
 use std::ffi::CString;
@@ -100,229 +101,167 @@ impl<'ctx> crate::backend::codegen::LLVMCodegen<'ctx> {
             .module
             .create_jit_execution_engine(OptimizationLevel::Aggressive)?;
 
-        if let Some(f) = self.module.get_function("free") {
-            ee.add_global_mapping(&f, std_free as *const () as usize);
+        // ── Prelude runtime mappings ─────────────────────────────────────
+        // First mapping tier: std host implementations for the symbols the
+        // codegen may reference. Kept as a single table (single source of
+        // truth) so the numbered-duplicate pass below can see every base name.
+        let prelude_fns: Vec<(&str, usize)> = {
+            let v: Vec<(&str, usize)> = vec![
+                ("free", std_free as *const () as usize),
+                ("host_str_concat", host_str_concat as *const () as usize),
+                (
+                    "host_str_to_lowercase",
+                    host_str_to_lowercase as *const () as usize,
+                ),
+                (
+                    "host_str_to_uppercase",
+                    host_str_to_uppercase as *const () as usize,
+                ),
+                ("host_str_trim", host_str_trim as *const () as usize),
+                ("host_str_len", host_str_len as *const () as usize),
+                (
+                    "host_str_starts_with",
+                    host_str_starts_with as *const () as usize,
+                ),
+                (
+                    "host_str_ends_with",
+                    host_str_ends_with as *const () as usize,
+                ),
+                ("host_str_contains", host_str_contains as *const () as usize),
+                ("host_str_replace", host_str_replace as *const () as usize),
+                (
+                    "host_str_split",
+                    crate::runtime::host::host_str_split as *const () as usize,
+                ),
+                (
+                    "host_str_join",
+                    crate::runtime::host::host_str_join as *const () as usize,
+                ),
+                (
+                    "host_str_find",
+                    crate::runtime::host::host_str_find as *const () as usize,
+                ),
+                (
+                    "host_str_count",
+                    crate::runtime::host::host_str_count as *const () as usize,
+                ),
+                (
+                    "host_str_strip",
+                    crate::runtime::host::host_str_strip as *const () as usize,
+                ),
+                (
+                    "host_str_lstrip",
+                    crate::runtime::host::host_str_lstrip as *const () as usize,
+                ),
+                (
+                    "host_str_rstrip",
+                    crate::runtime::host::host_str_rstrip as *const () as usize,
+                ),
+                (
+                    "host_str_isalpha",
+                    crate::runtime::host::host_str_isalpha as *const () as usize,
+                ),
+                (
+                    "host_str_isnumeric",
+                    crate::runtime::host::host_str_isnumeric as *const () as usize,
+                ),
+                ("channel_send", host_channel_send as *const () as usize),
+                ("channel_recv", host_channel_recv as *const () as usize),
+                ("host_mpsc_channel", host_mpsc_channel as *const () as usize),
+                ("host_mpsc_send", host_mpsc_send as *const () as usize),
+                ("host_mpsc_recv", host_mpsc_recv as *const () as usize),
+                (
+                    "host_mpsc_try_recv",
+                    host_mpsc_try_recv as *const () as usize,
+                ),
+                ("spawn", host_spawn as *const () as usize),
+                ("http_get", host_http_get as *const () as usize),
+                ("tls_handshake", host_tls_handshake as *const () as usize),
+                ("host_result_is_ok", host_result_is_ok as *const () as usize),
+                (
+                    "host_result_get_data",
+                    host_result_get_data as *const () as usize,
+                ),
+                ("map_new", host_map_new as *const () as usize),
+                ("map_insert", host_map_insert as *const () as usize),
+                ("map_get", host_map_get as *const () as usize),
+                (
+                    "scheduler::init_runtime",
+                    crate::runtime::actor::scheduler::init_runtime as *const () as usize,
+                ),
+                ("array_new", array_new as *const () as usize),
+                ("array_push", array_push as *const () as usize),
+                ("array_len", array_len as *const () as usize),
+                ("array_get", array_get as *const () as usize),
+                ("array_set", array_set as *const () as usize),
+                ("array_free", array_free as *const () as usize),
+                (
+                    "future_poll_alloc",
+                    crate::runtime::host::future_poll_alloc as *const () as usize,
+                ),
+                (
+                    "future_poll_free",
+                    crate::runtime::host::future_poll_free as *const () as usize,
+                ),
+                (
+                    "future_state_get",
+                    crate::runtime::host::future_state_get as *const () as usize,
+                ),
+                (
+                    "future_state_set",
+                    crate::runtime::host::future_state_set as *const () as usize,
+                ),
+                (
+                    "future_poll",
+                    crate::runtime::host::future_poll as *const () as usize,
+                ),
+                (
+                    "future_result",
+                    crate::runtime::host::future_result as *const () as usize,
+                ),
+                (
+                    "future_ready",
+                    crate::runtime::host::future_ready as *const () as usize,
+                ),
+                (
+                    "zeta_array_get_i64",
+                    zeta_array_get_i64 as *const () as usize,
+                ),
+                (
+                    "zeta_array_set_i64",
+                    zeta_array_set_i64 as *const () as usize,
+                ),
+                (
+                    "zeta_array_get_bool",
+                    zeta_array_get_bool as *const () as usize,
+                ),
+                (
+                    "zeta_array_set_bool",
+                    zeta_array_set_bool as *const () as usize,
+                ),
+                ("zeta_sieve_new", zeta_sieve_new as *const () as usize),
+                ("zeta_print_i64", zeta_print_i64 as *const () as usize),
+                ("zeta_println_i64", zeta_println_i64 as *const () as usize),
+                ("println_i64", zeta_println_i64 as *const () as usize),
+            ];
+            // Waker host fns exist only on Linux (reactor is Linux-only).
+            #[cfg(target_os = "linux")]
+            {
+                let mut v = v;
+                v.push(("create_waker", waker_create as *const () as usize));
+                v.push(("wake_waker", waker_wake as *const () as usize));
+                v
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                v
+            }
+        };
+        for (name, fn_ptr) in &prelude_fns {
+            if let Some(f) = self.module.get_function(name) {
+                ee.add_global_mapping(&f, *fn_ptr);
+            }
         }
-        if let Some(f) = self.module.get_function("host_str_concat") {
-            ee.add_global_mapping(&f, host_str_concat as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_str_to_lowercase") {
-            ee.add_global_mapping(&f, host_str_to_lowercase as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_str_to_uppercase") {
-            ee.add_global_mapping(&f, host_str_to_uppercase as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_str_trim") {
-            ee.add_global_mapping(&f, host_str_trim as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_str_len") {
-            ee.add_global_mapping(&f, host_str_len as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_str_starts_with") {
-            ee.add_global_mapping(&f, host_str_starts_with as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_str_ends_with") {
-            ee.add_global_mapping(&f, host_str_ends_with as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_str_contains") {
-            ee.add_global_mapping(&f, host_str_contains as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_str_replace") {
-            ee.add_global_mapping(&f, host_str_replace as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_str_split") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::host_str_split as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("host_str_join") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::host_str_join as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("host_str_find") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::host_str_find as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("host_str_count") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::host_str_count as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("host_str_strip") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::host_str_strip as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("host_str_lstrip") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::host_str_lstrip as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("host_str_rstrip") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::host_str_rstrip as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("host_str_isalpha") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::host_str_isalpha as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("host_str_isnumeric") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::host_str_isnumeric as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("channel_send") {
-            ee.add_global_mapping(&f, host_channel_send as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("channel_recv") {
-            ee.add_global_mapping(&f, host_channel_recv as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_mpsc_channel") {
-            ee.add_global_mapping(&f, host_mpsc_channel as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_mpsc_send") {
-            ee.add_global_mapping(&f, host_mpsc_send as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_mpsc_recv") {
-            ee.add_global_mapping(&f, host_mpsc_recv as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_mpsc_try_recv") {
-            ee.add_global_mapping(&f, host_mpsc_try_recv as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("create_waker") {
-            ee.add_global_mapping(&f, waker_create as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("wake_waker") {
-            ee.add_global_mapping(&f, waker_wake as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("spawn") {
-            ee.add_global_mapping(&f, host_spawn as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("http_get") {
-            ee.add_global_mapping(&f, host_http_get as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("tls_handshake") {
-            ee.add_global_mapping(&f, host_tls_handshake as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_result_is_ok") {
-            ee.add_global_mapping(&f, host_result_is_ok as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("host_result_get_data") {
-            ee.add_global_mapping(&f, host_result_get_data as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("map_new") {
-            ee.add_global_mapping(&f, host_map_new as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("map_insert") {
-            ee.add_global_mapping(&f, host_map_insert as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("map_get") {
-            ee.add_global_mapping(&f, host_map_get as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("scheduler::init_runtime") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::actor::scheduler::init_runtime as *const () as usize,
-            );
-        }
-
-        // Array runtime functions
-        if let Some(f) = self.module.get_function("array_new") {
-            ee.add_global_mapping(&f, array_new as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("array_push") {
-            ee.add_global_mapping(&f, array_push as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("array_len") {
-            ee.add_global_mapping(&f, array_len as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("array_get") {
-            ee.add_global_mapping(&f, array_get as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("array_set") {
-            ee.add_global_mapping(&f, array_set as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("array_free") {
-            ee.add_global_mapping(&f, array_free as *const () as usize);
-        }
-
-        // Async/future runtime functions
-        if let Some(f) = self.module.get_function("future_poll_alloc") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::future_poll_alloc as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("future_poll_free") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::future_poll_free as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("future_state_get") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::future_state_get as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("future_state_set") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::future_state_set as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("future_poll") {
-            ee.add_global_mapping(&f, crate::runtime::host::future_poll as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("future_result") {
-            ee.add_global_mapping(
-                &f,
-                crate::runtime::host::future_result as *const () as usize,
-            );
-        }
-        if let Some(f) = self.module.get_function("future_ready") {
-            ee.add_global_mapping(&f, crate::runtime::host::future_ready as *const () as usize);
-        }
-
-        // Zeta runtime mapping
-        if let Some(f) = self.module.get_function("zeta_array_get_i64") {
-            ee.add_global_mapping(&f, zeta_array_get_i64 as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("zeta_array_set_i64") {
-            ee.add_global_mapping(&f, zeta_array_set_i64 as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("zeta_array_get_bool") {
-            ee.add_global_mapping(&f, zeta_array_get_bool as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("zeta_array_set_bool") {
-            ee.add_global_mapping(&f, zeta_array_set_bool as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("zeta_sieve_new") {
-            ee.add_global_mapping(&f, zeta_sieve_new as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("zeta_print_i64") {
-            ee.add_global_mapping(&f, zeta_print_i64 as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("zeta_println_i64") {
-            ee.add_global_mapping(&f, zeta_println_i64 as *const () as usize);
-        }
-        if let Some(f) = self.module.get_function("println_i64") {
-            ee.add_global_mapping(&f, zeta_println_i64 as *const () as usize);
-        }
-
         // Map Vec runtime functions (zeta_vec_* → vec_*)
         let vec_fns: Vec<(&str, usize)> = vec![
             (
@@ -662,6 +601,453 @@ impl<'ctx> crate::backend::codegen::LLVMCodegen<'ctx> {
         for (name, fn_ptr) in &tier3_fns {
             if let Some(f) = self.module.get_function(name) {
                 ee.add_global_mapping(&f, *fn_ptr);
+            }
+        }
+
+        // ── Explicit runtime mappings ──────────────────────────────────────
+        // The codegen declares a fixed set of standard runtime symbols in
+        // every module. On Linux some of them resolve via dlsym (the binary
+        // is linked with -rdynamic), but macOS does not export process
+        // symbols to dlsym — an declared-but-unmapped function resolves to
+        // NULL and segfaults when the JITed code calls it. Mapping each
+        // symbol explicitly makes JIT resolution platform-independent.
+        let explicit: Vec<(&str, usize)> = vec![
+            // I/O
+            (
+                "print_i64",
+                crate::runtime::io::print_i64 as *const () as usize,
+            ),
+            (
+                "print_bool",
+                crate::runtime::io::print_bool as *const () as usize,
+            ),
+            (
+                "print_str",
+                crate::runtime::io::print_str as *const () as usize,
+            ),
+            ("flush", crate::runtime::io::flush as *const () as usize),
+            (
+                "test_return_i64",
+                crate::runtime::io::test_return_i64 as *const () as usize,
+            ),
+            // Portable fd/clock helpers
+            (
+                "set_nonblocking",
+                crate::runtime::io::set_nonblocking as *const () as usize,
+            ),
+            (
+                "monotonic_ns",
+                crate::runtime::io::monotonic_ns as *const () as usize,
+            ),
+            (
+                "datetime_now",
+                crate::runtime::jit_stubs::datetime_now as *const () as usize,
+            ),
+            (
+                "get_time_us",
+                crate::runtime::jit_stubs::get_time_us as *const () as usize,
+            ),
+            // Heap allocator
+            (
+                "runtime_malloc",
+                crate::runtime::host::runtime_malloc as *const () as usize,
+            ),
+            (
+                "runtime_free",
+                crate::runtime::memory::runtime_free as *const () as usize,
+            ),
+            (
+                "runtime_calloc",
+                crate::runtime::memory::runtime_calloc as *const () as usize,
+            ),
+            (
+                "runtime_realloc",
+                crate::runtime::memory::runtime_realloc as *const () as usize,
+            ),
+            // Result / Option / Map
+            (
+                "host_result_make_ok",
+                crate::runtime::actor::result::host_result_make_ok as *const () as usize,
+            ),
+            (
+                "host_result_make_err",
+                crate::runtime::actor::result::host_result_make_err as *const () as usize,
+            ),
+            (
+                "host_result_free",
+                crate::runtime::actor::result::host_result_free as *const () as usize,
+            ),
+            (
+                "option_make_some",
+                crate::runtime::option::option_make_some as *const () as usize,
+            ),
+            (
+                "option_make_none",
+                crate::runtime::option::option_make_none as *const () as usize,
+            ),
+            (
+                "option_is_some",
+                crate::runtime::option::option_is_some as *const () as usize,
+            ),
+            (
+                "option_get_data",
+                crate::runtime::option::option_get_data as *const () as usize,
+            ),
+            (
+                "option_free",
+                crate::runtime::option::option_free as *const () as usize,
+            ),
+            (
+                "map_free",
+                crate::runtime::map::map_free as *const () as usize,
+            ),
+            // Array / stack-array
+            (
+                "array_set_len",
+                crate::runtime::array::array_set_len as *const () as usize,
+            ),
+            (
+                "stack_array_get",
+                crate::runtime::array::stack_array_get as *const () as usize,
+            ),
+            (
+                "stack_array_set",
+                crate::runtime::array::stack_array_set as *const () as usize,
+            ),
+            // Host string helpers
+            (
+                "host_str_count",
+                crate::runtime::host::host_str_count as *const () as usize,
+            ),
+            (
+                "host_str_strip",
+                crate::runtime::host::host_str_strip as *const () as usize,
+            ),
+            (
+                "host_str_lstrip",
+                crate::runtime::host::host_str_lstrip as *const () as usize,
+            ),
+            (
+                "host_str_rstrip",
+                crate::runtime::host::host_str_rstrip as *const () as usize,
+            ),
+            (
+                "host_str_isalpha",
+                crate::runtime::host::host_str_isalpha as *const () as usize,
+            ),
+            (
+                "host_str_isnumeric",
+                crate::runtime::host::host_str_isnumeric as *const () as usize,
+            ),
+            // Clone / null-check / to-string helpers
+            (
+                "clone_i64",
+                crate::runtime::host::clone_i64 as *const () as usize,
+            ),
+            (
+                "clone_bool",
+                crate::runtime::host::clone_bool as *const () as usize,
+            ),
+            (
+                "is_null_i64",
+                crate::runtime::host::is_null_i64 as *const () as usize,
+            ),
+            (
+                "is_null_bool",
+                crate::runtime::host::is_null_bool as *const () as usize,
+            ),
+            (
+                "to_string_i64",
+                crate::runtime::host::to_string_i64 as *const () as usize,
+            ),
+            (
+                "to_string_bool",
+                crate::runtime::host::to_string_bool as *const () as usize,
+            ),
+            (
+                "to_string_str",
+                crate::runtime::host::to_string_str as *const () as usize,
+            ),
+            // Stubs (no host implementation exists)
+            (
+                "time_is_up",
+                crate::runtime::jit_stubs::time_is_up as *const () as usize,
+            ),
+            (
+                "print_result",
+                crate::runtime::jit_stubs::print_result as *const () as usize,
+            ),
+            (
+                "run_sieve",
+                crate::runtime::jit_stubs::run_sieve as *const () as usize,
+            ),
+            (
+                "run_sieve_timed",
+                crate::runtime::jit_stubs::run_sieve_timed as *const () as usize,
+            ),
+            (
+                "parallel_sieve",
+                crate::runtime::jit_stubs::parallel_sieve as *const () as usize,
+            ),
+            (
+                "parallel_sieve_timed",
+                crate::runtime::jit_stubs::parallel_sieve_timed as *const () as usize,
+            ),
+            (
+                "sieve_step",
+                crate::runtime::jit_stubs::sieve_step as *const () as usize,
+            ),
+            (
+                "call_i64",
+                crate::runtime::jit_stubs::call_i64 as *const () as usize,
+            ),
+            (
+                "avx512_byte_fill",
+                crate::runtime::jit_stubs::avx512_byte_fill as *const () as usize,
+            ),
+            (
+                "avx512_count_bits",
+                crate::runtime::jit_stubs::avx512_count_bits as *const () as usize,
+            ),
+            (
+                "__builtin_v4i64_andnot",
+                crate::runtime::jit_stubs::__builtin_v4i64_andnot as *const () as usize,
+            ),
+            (
+                "__builtin_v4i64_store",
+                crate::runtime::jit_stubs::__builtin_v4i64_store as *const () as usize,
+            ),
+            (
+                "read_qword_builtin",
+                crate::runtime::jit_stubs::read_qword_builtin as *const () as usize,
+            ),
+            (
+                "write_qword_builtin",
+                crate::runtime::jit_stubs::write_qword_builtin as *const () as usize,
+            ),
+            (
+                "clear_bit",
+                crate::runtime::jit_stubs::clear_bit as *const () as usize,
+            ),
+            (
+                "test_bit",
+                crate::runtime::jit_stubs::test_bit as *const () as usize,
+            ),
+            // Operator functions (plain + quoted LLVM names)
+            (
+                "add_i64",
+                crate::runtime::jit_stubs::add_i64 as *const () as usize,
+            ),
+            (
+                "+",
+                crate::runtime::jit_stubs::add_i64 as *const () as usize,
+            ),
+            (
+                "sub_i64",
+                crate::runtime::jit_stubs::sub_i64 as *const () as usize,
+            ),
+            (
+                "-",
+                crate::runtime::jit_stubs::sub_i64 as *const () as usize,
+            ),
+            (
+                "mul_i64",
+                crate::runtime::jit_stubs::mul_i64 as *const () as usize,
+            ),
+            (
+                "*",
+                crate::runtime::jit_stubs::mul_i64 as *const () as usize,
+            ),
+            (
+                "div_i64",
+                crate::runtime::jit_stubs::div_i64 as *const () as usize,
+            ),
+            (
+                "/",
+                crate::runtime::jit_stubs::div_i64 as *const () as usize,
+            ),
+            (
+                "mod_i64",
+                crate::runtime::jit_stubs::mod_i64 as *const () as usize,
+            ),
+            (
+                "%",
+                crate::runtime::jit_stubs::mod_i64 as *const () as usize,
+            ),
+            (
+                "and_i64",
+                crate::runtime::jit_stubs::and_i64 as *const () as usize,
+            ),
+            (
+                "or_i64",
+                crate::runtime::jit_stubs::or_i64 as *const () as usize,
+            ),
+            (
+                "xor_i64",
+                crate::runtime::jit_stubs::xor_i64 as *const () as usize,
+            ),
+            (
+                "not_i64",
+                crate::runtime::jit_stubs::not_i64 as *const () as usize,
+            ),
+            (
+                "shl_i64",
+                crate::runtime::jit_stubs::shl_i64 as *const () as usize,
+            ),
+            (
+                "shr_i64",
+                crate::runtime::jit_stubs::shr_i64 as *const () as usize,
+            ),
+            (
+                "eq_i64",
+                crate::runtime::jit_stubs::eq_i64 as *const () as usize,
+            ),
+            (
+                "==",
+                crate::runtime::jit_stubs::eq_i64 as *const () as usize,
+            ),
+            (
+                "ne_i64",
+                crate::runtime::jit_stubs::ne_i64 as *const () as usize,
+            ),
+            (
+                "!=",
+                crate::runtime::jit_stubs::ne_i64 as *const () as usize,
+            ),
+            (
+                "lt_i64",
+                crate::runtime::jit_stubs::lt_i64 as *const () as usize,
+            ),
+            ("<", crate::runtime::jit_stubs::lt_i64 as *const () as usize),
+            (
+                "gt_i64",
+                crate::runtime::jit_stubs::gt_i64 as *const () as usize,
+            ),
+            (">", crate::runtime::jit_stubs::gt_i64 as *const () as usize),
+            (
+                "le_i64",
+                crate::runtime::jit_stubs::le_i64 as *const () as usize,
+            ),
+            (
+                "<=",
+                crate::runtime::jit_stubs::le_i64 as *const () as usize,
+            ),
+            (
+                "ge_i64",
+                crate::runtime::jit_stubs::ge_i64 as *const () as usize,
+            ),
+            (
+                ">=",
+                crate::runtime::jit_stubs::ge_i64 as *const () as usize,
+            ),
+        ];
+        for (name, fn_ptr) in &explicit {
+            if let Some(f) = self.module.get_function(name) {
+                ee.add_global_mapping(&f, *fn_ptr);
+            }
+        }
+
+        // Async runtime family: real implementations on Linux, no-op stubs
+        // elsewhere (the epoll/timerfd reactor is Linux-only).
+        let async_fns: Vec<(&str, usize)> = {
+            #[cfg(target_os = "linux")]
+            {
+                use crate::runtime::reactor as rt;
+                vec![
+                    ("reactor_create", rt::reactor_create as *const () as usize),
+                    ("reactor_add", rt::reactor_add as *const () as usize),
+                    ("reactor_remove", rt::reactor_remove as *const () as usize),
+                    ("reactor_poll", rt::reactor_poll as *const () as usize),
+                    (
+                        "reactor_event_fd",
+                        rt::reactor_event_fd as *const () as usize,
+                    ),
+                    (
+                        "reactor_event_flags",
+                        rt::reactor_event_flags as *const () as usize,
+                    ),
+                    ("reactor_destroy", rt::reactor_destroy as *const () as usize),
+                    ("waker_create", rt::waker_create as *const () as usize),
+                    ("waker_wake", rt::waker_wake as *const () as usize),
+                    ("waker_consume", rt::waker_consume as *const () as usize),
+                    ("waker_destroy", rt::waker_destroy as *const () as usize),
+                    (
+                        "scheduler_register_waker",
+                        rt::scheduler_register_waker as *const () as usize,
+                    ),
+                    (
+                        "scheduler_run_reactor",
+                        rt::scheduler_run_reactor as *const () as usize,
+                    ),
+                ]
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                use crate::runtime::jit_stubs::async_stubs as st;
+                vec![
+                    ("reactor_create", st::reactor_create as *const () as usize),
+                    ("reactor_add", st::reactor_add as *const () as usize),
+                    ("reactor_remove", st::reactor_remove as *const () as usize),
+                    ("reactor_poll", st::reactor_poll as *const () as usize),
+                    (
+                        "reactor_event_fd",
+                        st::reactor_event_fd as *const () as usize,
+                    ),
+                    (
+                        "reactor_event_flags",
+                        st::reactor_event_flags as *const () as usize,
+                    ),
+                    ("reactor_destroy", st::reactor_destroy as *const () as usize),
+                    ("waker_create", st::waker_create as *const () as usize),
+                    ("waker_wake", st::waker_wake as *const () as usize),
+                    ("waker_consume", st::waker_consume as *const () as usize),
+                    ("waker_destroy", st::waker_destroy as *const () as usize),
+                    (
+                        "scheduler_register_waker",
+                        st::scheduler_register_waker as *const () as usize,
+                    ),
+                    (
+                        "scheduler_run_reactor",
+                        st::scheduler_run_reactor as *const () as usize,
+                    ),
+                ]
+            }
+        };
+        for (name, fn_ptr) in &async_fns {
+            if let Some(f) = self.module.get_function(name) {
+                ee.add_global_mapping(&f, *fn_ptr);
+            }
+        }
+
+        // Defensive: LLVM uniquing renames a re-declaration of an existing name to
+        // `name.N` (see the std-declaration blocks in codegen.rs). If a call site
+        // binds to such a numbered duplicate, it has no mapping above and resolves
+        // to NULL (segfault). Map any numbered duplicate of a known runtime symbol
+        // to the same target as its base.
+        let base_map: std::collections::HashMap<String, usize> = prelude_fns
+            .iter()
+            .chain(vec_fns.iter())
+            .chain(tier2_fns.iter())
+            .chain(tier3_fns.iter())
+            .chain(explicit.iter())
+            .chain(async_fns.iter())
+            .map(|(n, p)| (n.to_string(), *p))
+            .collect();
+        for f in self.module.get_functions() {
+            // Declarations only: a numbered runtime duplicate never has a body;
+            // user-defined functions must never be remapped.
+            if !f.get_basic_blocks().is_empty() {
+                continue;
+            }
+            let name = f.get_name().to_str().unwrap_or("").to_string();
+            if let Some(dot) = name.rfind('.') {
+                let suffix = &name[dot + 1..];
+                if !suffix.is_empty()
+                    && suffix.bytes().all(|b| b.is_ascii_digit())
+                    && let Some(ptr) = base_map.get(&name[..dot])
+                {
+                    ee.add_global_mapping(&f, *ptr);
+                }
             }
         }
 

--- a/src/backend/codegen/monomorphize.rs
+++ b/src/backend/codegen/monomorphize.rs
@@ -382,6 +382,7 @@ mod tests {
             type_map: HashMap::new(),
             global_consts: HashMap::new(),
             properties: vec![],
+            is_extern: false,
         };
 
         // Add some types with variables
@@ -423,6 +424,7 @@ mod tests {
             type_map: HashMap::new(),
             global_consts: HashMap::new(),
             properties: vec![],
+            is_extern: false,
         };
 
         mir.type_map.insert(1, Type::I32);

--- a/src/frontend/cfg.rs
+++ b/src/frontend/cfg.rs
@@ -75,7 +75,8 @@ fn eval_predicate(pred: &str, features: &[String]) -> bool {
 
     // `all(p1, p2, ...)`
     if pred.starts_with("all(") && pred.ends_with(')') {
-        let inner = &pred[3..pred.len() - 1];
+        // `all(` is 4 characters — strip the keyword, the open paren, and the trailing paren.
+        let inner = &pred[4..pred.len() - 1];
         return split_predicates(inner)
             .iter()
             .all(|p| eval_predicate(p, features));
@@ -153,15 +154,27 @@ mod tests {
     #[test]
     fn test_any() {
         let features = vec!["xxh64".to_string()];
-        assert!(eval_predicate(r#"any(feature = "xxh64", feature = "xxh3")"#, &features));
-        assert!(!eval_predicate(r#"any(feature = "xxh3", feature = "xxh32")"#, &features));
+        assert!(eval_predicate(
+            r#"any(feature = "xxh64", feature = "xxh3")"#,
+            &features
+        ));
+        assert!(!eval_predicate(
+            r#"any(feature = "xxh3", feature = "xxh32")"#,
+            &features
+        ));
     }
 
     #[test]
     fn test_all() {
         let features = vec!["a".to_string(), "b".to_string()];
-        assert!(eval_predicate(r#"all(feature = "a", feature = "b")"#, &features));
-        assert!(!eval_predicate(r#"all(feature = "a", feature = "c")"#, &features));
+        assert!(eval_predicate(
+            r#"all(feature = "a", feature = "b")"#,
+            &features
+        ));
+        assert!(!eval_predicate(
+            r#"all(feature = "a", feature = "c")"#,
+            &features
+        ));
     }
 
     #[test]

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1,8 +1,8 @@
 // src/frontend/mod.rs
 pub mod ast;
 pub mod borrow;
-pub mod cfg;
 pub mod borrow_enhanced;
+pub mod cfg;
 pub mod identity_ownership;
 pub mod macro_expand;
 pub mod macro_expand_advanced;

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,19 +292,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     // Platform-specific linking
                     if target == "wasm32" || target == "wasm32-wasi" {
                         let wasm_path = format!("{}.wasm", out);
-                        // Try wasm-ld; fall back to versioned variant (wasm-ld-21, etc.)
+                        // Try wasm-ld; fall back to versioned variant (wasm-ld-22, etc.)
                         let wasm_ld = if std::process::Command::new("wasm-ld")
                             .arg("--version")
                             .output()
                             .is_ok()
                         {
                             "wasm-ld"
-                        } else if std::process::Command::new("wasm-ld-21")
+                        } else if std::process::Command::new("wasm-ld-22")
                             .arg("--version")
                             .output()
                             .is_ok()
                         {
-                            "wasm-ld-21"
+                            "wasm-ld-22"
                         } else {
                             return Err("WASM linker not found. Install wasm-ld (part of LLVM) or WASI SDK.".into());
                         };

--- a/src/middle/mir/gen.rs
+++ b/src/middle/mir/gen.rs
@@ -161,13 +161,11 @@ impl MirGen {
             },
             // Count params for potential name mangling (used by get_or_declare_function)
             param_indices: match ast {
-                AstNode::FuncDef { params, .. } | AstNode::ExternFunc { params, .. } => {
-                    params
-                        .iter()
-                        .enumerate()
-                        .map(|(i, (n, _))| (n.clone(), i as u32))
-                        .collect()
-                }
+                AstNode::FuncDef { params, .. } | AstNode::ExternFunc { params, .. } => params
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (n, _))| (n.clone(), i as u32))
+                    .collect(),
                 _ => vec![],
             },
             properties: if let AstNode::FuncDef { attrs, .. } = ast {
@@ -1189,8 +1187,7 @@ impl MirGen {
                             return id;
                         }
                         crate::middle::ctfe::value::ConstValue::String(s) => {
-                            self.exprs
-                                .insert(id, MirExpr::StringLit(s.clone()));
+                            self.exprs.insert(id, MirExpr::StringLit(s.clone()));
                             self.type_map.insert(id, Type::Str);
                             return id;
                         }
@@ -1552,7 +1549,7 @@ impl MirGen {
                 }
 
                 // SPECIAL HANDLING: syscall() — emits raw Linux syscall via inline asm
-                if method == "syscall" && receiver.is_none() && args.len() >= 1 {
+                if method == "syscall" && receiver.is_none() && !args.is_empty() {
                     let num_id = self.lower_expr(&args[0]);
                     let mut arg_ids = Vec::new();
                     for i in 1..args.len() {
@@ -1818,14 +1815,23 @@ impl MirGen {
                     arg_ids.push(self.lower_expr(a));
                 }
 
-                // Check if this is a method call on a dynamic array
+                // Check if this is a method call on an array-like type
                 let (func, is_array_len, is_array_push) = if let Some(ref rty) = receiver_ty {
-                    // Check if receiver is a dynamic array type
-                    if let Type::DynamicArray(_) = rty {
+                    // All array-like receivers ([T; N], [T], [dynamic]T) lower to the
+                    // runtime array_* helpers — the receiver is just a data pointer.
+                    // Without this, e.g. bits.append(1) on a [u8] binding falls through
+                    // to a bare `append` extern that the JIT cannot resolve (NULL crash).
+                    let is_array_like = matches!(
+                        rty,
+                        Type::Array(_, _) | Type::Slice(_) | Type::DynamicArray(_)
+                    );
+                    if is_array_like {
                         // Map array methods to runtime functions
                         match method.as_str() {
-                            "push" => ("array_push".to_string(), false, true),
-                            "len" => ("array_len".to_string(), true, false),
+                            "push" | "append" => ("array_push".to_string(), false, true),
+                            "len" | "length" | "count" => ("array_len".to_string(), true, false),
+                            "get" => ("array_get".to_string(), false, false),
+                            "set" => ("array_set".to_string(), false, false),
                             _ => {
                                 // For other methods, use qualified name: Type::method
                                 let rty_name = rty.display_name();

--- a/src/middle/optimization.rs
+++ b/src/middle/optimization.rs
@@ -274,7 +274,11 @@ pub fn common_subexpression_elimination(mir: &mut Mir) {
             MirExpr::Deref { addr_id, .. } => format!("Deref({})", addr_id),
             MirExpr::TimingOwned(inner_id) => format!("TimingOwned({})", inner_id),
             MirExpr::Syscall(num_id, arg_ids) => {
-                let args = arg_ids.iter().map(|a| a.to_string()).collect::<Vec<_>>().join(",");
+                let args = arg_ids
+                    .iter()
+                    .map(|a| a.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",");
                 format!("Syscall({},[{}])", num_id, args)
             }
             MirExpr::StringLit(s) => format!("StringLit({})", s),

--- a/src/middle/resolver/module_resolver.rs
+++ b/src/middle/resolver/module_resolver.rs
@@ -244,7 +244,7 @@ impl ModuleResolver {
             // Look for the package in the packages directory
             // Structure: packages/@scope/name/src/mod.z
             let pkg_path = PathBuf::from("packages").join(scoped_name).join("src");
-            
+
             // Try as a module path (e.g., use @io/uring::Ring -> packages/@io/uring/src/mod.z)
             let mut mod_z = pkg_path.clone();
             mod_z.push("mod.z");
@@ -252,7 +252,7 @@ impl ModuleResolver {
                 return Ok(mod_z);
             }
 
-            // Try as fully-qualified package path (e.g., use @io/uring::sqe::write -> packages/@io/uring/src/sqe.z)  
+            // Try as fully-qualified package path (e.g., use @io/uring::sqe::write -> packages/@io/uring/src/sqe.z)
             if path.len() > 2 {
                 let mut sub_path = pkg_path.clone();
                 for comp in &path[1..path.len() - 1] {
@@ -275,7 +275,7 @@ impl ModuleResolver {
 
             // Check the zorb package cache (~/.cache/zorb/packages/@scope/name/...)
             let home = std::env::var("HOME").unwrap_or_else(|_| "/home/zeta".to_string());
-            let mut cache_path = PathBuf::from(&home)
+            let cache_path = PathBuf::from(&home)
                 .join(".cache/zorb/packages")
                 .join(scoped_name)
                 .join("src");
@@ -713,7 +713,6 @@ impl ModuleResolver {
             params: vec![("size".to_string(), "i64".to_string())],
             ret: "i64".to_string(),
             where_clauses: vec![],
-
         };
         asts.push(malloc_func.clone());
         exports.insert("malloc".to_string(), malloc_func);
@@ -726,7 +725,6 @@ impl ModuleResolver {
             params: vec![("ptr".to_string(), "i64".to_string())],
             ret: "()".to_string(),
             where_clauses: vec![],
-
         };
         asts.push(free_func.clone());
         exports.insert("free".to_string(), free_func);
@@ -739,7 +737,6 @@ impl ModuleResolver {
             params: vec![("msg".to_string(), "i64".to_string())],
             ret: "()".to_string(),
             where_clauses: vec![],
-
         };
         asts.push(print_func.clone());
         exports.insert("print".to_string(), print_func);
@@ -752,7 +749,6 @@ impl ModuleResolver {
             params: vec![("msg".to_string(), "i64".to_string())],
             ret: "()".to_string(),
             where_clauses: vec![],
-
         };
         asts.push(println_func.clone());
         exports.insert("println".to_string(), println_func);

--- a/src/middle/resolver/resolver.rs
+++ b/src/middle/resolver/resolver.rs
@@ -250,12 +250,41 @@ impl Resolver {
                         }
                     }
                     Err(e) => {
-                        crate::diag_warning!(
-                            "W2002",
-                            "Failed to process use statement {}: {}",
-                            path.join("::"),
-                            e
-                        );
+                        // File resolution failed. The path may refer to an item in
+                        // an inline module of THIS file (mod math { ... } +
+                        // use math::add;) — process_use_statement only handles
+                        // file-backed modules. The ModDef arm above already
+                        // registered the item under its qualified name; alias it
+                        // under the plain import name (the same treatment file
+                        // imports get). Without this, unqualified calls resolve to
+                        // an unmapped extern declaration and crash at runtime.
+                        //
+                        // Caveat: single-pass registration, so this only aliases
+                        // when the `mod` appears before the `use` in the file.
+                        let aliased = match path.as_slice() {
+                            [module, item] if !self.registered_funcs.contains_key(item) => {
+                                let qualified = format!("{}::{}", module, item);
+                                match self.registered_funcs.get(&qualified).cloned() {
+                                    Some(mut ast @ AstNode::FuncDef { .. }) => {
+                                        if let AstNode::FuncDef { name, .. } = &mut ast {
+                                            *name = item.clone();
+                                        }
+                                        self.register(ast);
+                                        true
+                                    }
+                                    _ => false,
+                                }
+                            }
+                            _ => false,
+                        };
+                        if !aliased {
+                            crate::diag_warning!(
+                                "W2002",
+                                "Failed to process use statement {}: {}",
+                                path.join("::"),
+                                e
+                            );
+                        }
                     }
                 }
             }

--- a/src/runtime/array.rs
+++ b/src/runtime/array.rs
@@ -63,20 +63,12 @@ unsafe fn check_canary(header: *const ArrayHeader) -> bool {
 ///
 /// # Safety
 /// Returns a pointer to data (after ArrayHeader), not to header
-#[allow(unreachable_code)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn array_new(capacity: usize) -> i64 {
-    // Just return a constant, no function calls
-    return 0x0BADF00D;
-
     // Calculate total size: header + data
     let elem_size = std::mem::size_of::<i64>();
     let data_size = capacity * elem_size;
     let total_size = ARRAY_HEADER_SIZE + data_size;
-    println!(
-        "[ARRAY_NEW] elem_size = {}, data_size = {}, total_size = {}",
-        elem_size, data_size, total_size
-    );
 
     // Allocate single contiguous block for header + data
     let align = std::cmp::max(
@@ -106,10 +98,6 @@ pub unsafe extern "C" fn array_new(capacity: usize) -> i64 {
 
     // Get data pointer (after header)
     let data_ptr = unsafe { get_data(header_ptr) };
-    println!(
-        "[ARRAY_NEW] header_ptr = {:?}, data_ptr = {:?}",
-        header_ptr, data_ptr
-    );
 
     // Initialize data with sanitization pattern (0xCD for uninitialized)
     unsafe {

--- a/src/runtime/io.rs
+++ b/src/runtime/io.rs
@@ -116,3 +116,26 @@ pub unsafe extern "C" fn println_str(ptr: i64) {
 pub unsafe extern "C" fn flush() {
     let _ = io::stdout().flush();
 }
+
+// ── Portable fd/clock helpers (moved out of reactor.rs: no epoll dependency) ──
+
+/// Set O_NONBLOCK on a file descriptor. Portable (fcntl on Linux and macOS).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn set_nonblocking(fd: i64) -> i64 {
+    let flags = libc::fcntl(fd as i32, libc::F_GETFL, 0);
+    if flags < 0 {
+        return -1;
+    }
+    libc::fcntl(fd as i32, libc::F_SETFL, flags | libc::O_NONBLOCK) as i64
+}
+
+/// Monotonic clock in nanoseconds. Portable (CLOCK_MONOTONIC on all unix hosts).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn monotonic_ns() -> i64 {
+    let mut ts: libc::timespec = std::mem::zeroed();
+    if libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) == 0 {
+        ts.tv_sec * 1_000_000_000 + ts.tv_nsec
+    } else {
+        -1
+    }
+}

--- a/src/runtime/jit_stubs.rs
+++ b/src/runtime/jit_stubs.rs
@@ -1,0 +1,205 @@
+//! Host stubs for standard runtime symbols that have no host implementation.
+//!
+//! The codegen declares a fixed set of standard runtime functions in every
+//! module (operators, sieve, SIMD builtins, async runtime, ...). The JIT
+//! must be able to resolve each one that the compiled code may call; a
+//! declaration without a mapping resolves to NULL and segfaults when called.
+//!
+//! These stubs are mapped in `jit.rs` (see the explicit mapping table). On
+//! Linux the async family maps to the real implementations in `reactor.rs`
+//! instead (see the cfg-gated table there).
+
+#![allow(dead_code, unused_variables)]
+
+// ── Clock helpers (real implementations — portable: libc clock_gettime) ──
+
+/// Current UNIX time in seconds.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn datetime_now() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(-1)
+}
+
+/// Monotonic clock in microseconds (zeroed at first call).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn get_time_us() -> i64 {
+    use std::time::Instant;
+    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+    let start = START.get_or_init(Instant::now);
+    start.elapsed().as_micros() as i64
+}
+
+// ── Test-harness helpers (no-op / inert) ──
+
+/// Inert: no timing source available to compare against.
+pub unsafe extern "C" fn time_is_up(_start_us: i64, _limit_us: i64) -> i64 {
+    0
+}
+
+/// Inert: test result printer has no portable behavior.
+pub unsafe extern "C" fn print_result(_a: i64, _b: i64) {}
+
+// ── Murphy sieve runtime (no Rust implementation exists) ──
+
+pub unsafe extern "C" fn run_sieve(_n: i64) -> i64 {
+    -1
+}
+pub unsafe extern "C" fn run_sieve_timed(_n: i64, _t: i64) -> i64 {
+    -1
+}
+pub unsafe extern "C" fn parallel_sieve(_n: i64, _t: i64) -> i64 {
+    -1
+}
+pub unsafe extern "C" fn parallel_sieve_timed(_n: i64, _t: i64, _x: i64) -> i64 {
+    -1
+}
+pub unsafe extern "C" fn sieve_step(_a: i64, _b: i64, _c: i64, _d: i64) {}
+
+// ── Generic call thunk ──
+
+/// Returns the callee pointer; never dereferenced.
+pub unsafe extern "C" fn call_i64(fn_ptr: i64, _arg: i64) -> i64 {
+    fn_ptr
+}
+
+// ── SIMD / vector builtins (inert on hosts without the feature) ──
+
+pub unsafe extern "C" fn avx512_byte_fill(_v: i64, _x: i64, _y: i64) {}
+pub unsafe extern "C" fn avx512_count_bits(_a: i64, _b: i64) -> i64 {
+    0
+}
+pub unsafe extern "C" fn __builtin_v4i64_andnot(
+    _a: i64,
+    _b: i64,
+    _c: i64,
+    _d: i64,
+    _e: i64,
+    _f: i64,
+) {
+}
+pub unsafe extern "C" fn __builtin_v4i64_store(
+    _a: i64,
+    _b: i64,
+    _c: i64,
+    _d: i64,
+    _e: i64,
+    _f: i64,
+) {
+}
+
+// ── Qword memory builtins (inert) ──
+
+pub unsafe extern "C" fn read_qword_builtin(_a: i64, _b: i64) -> i64 {
+    0
+}
+pub unsafe extern "C" fn write_qword_builtin(_a: i64, _b: i64, _c: i64) {}
+
+// ── Bit-vector helpers (inert) ──
+
+pub unsafe extern "C" fn clear_bit(_base: i64, _index: i64) {}
+pub unsafe extern "C" fn test_bit(_base: i64, _index: i64) -> i64 {
+    0
+}
+
+// ── Operator functions (wrapping arithmetic, total: no traps) ──
+
+pub unsafe extern "C" fn add_i64(a: i64, b: i64) -> i64 {
+    a.wrapping_add(b)
+}
+pub unsafe extern "C" fn sub_i64(a: i64, b: i64) -> i64 {
+    a.wrapping_sub(b)
+}
+pub unsafe extern "C" fn mul_i64(a: i64, b: i64) -> i64 {
+    a.wrapping_mul(b)
+}
+pub unsafe extern "C" fn div_i64(a: i64, b: i64) -> i64 {
+    if b == 0 { 0 } else { a.wrapping_div(b) }
+}
+pub unsafe extern "C" fn mod_i64(a: i64, b: i64) -> i64 {
+    if b == 0 { 0 } else { a.wrapping_rem(b) }
+}
+pub unsafe extern "C" fn and_i64(a: i64, b: i64) -> i64 {
+    a & b
+}
+pub unsafe extern "C" fn or_i64(a: i64, b: i64) -> i64 {
+    a | b
+}
+pub unsafe extern "C" fn xor_i64(a: i64, b: i64) -> i64 {
+    a ^ b
+}
+pub unsafe extern "C" fn not_i64(a: i64) -> i64 {
+    !a
+}
+pub unsafe extern "C" fn shl_i64(a: i64, b: i64) -> i64 {
+    a.wrapping_shl(b as u32 & 63)
+}
+pub unsafe extern "C" fn shr_i64(a: i64, b: i64) -> i64 {
+    a.wrapping_shr(b as u32 & 63)
+}
+pub unsafe extern "C" fn eq_i64(a: i64, b: i64) -> i64 {
+    (a == b) as i64
+}
+pub unsafe extern "C" fn ne_i64(a: i64, b: i64) -> i64 {
+    (a != b) as i64
+}
+pub unsafe extern "C" fn lt_i64(a: i64, b: i64) -> i64 {
+    (a < b) as i64
+}
+pub unsafe extern "C" fn gt_i64(a: i64, b: i64) -> i64 {
+    (a > b) as i64
+}
+pub unsafe extern "C" fn le_i64(a: i64, b: i64) -> i64 {
+    (a <= b) as i64
+}
+pub unsafe extern "C" fn ge_i64(a: i64, b: i64) -> i64 {
+    (a >= b) as i64
+}
+
+// ── Async runtime stubs (non-Linux only) ──
+//
+// On Linux these symbols map to the real implementations in `reactor.rs`
+// (see the cfg-gated table in jit.rs). On other hosts the async reactor is
+// unavailable: the stubs let the JIT resolve the standard declarations
+// instead of leaving them as NULL (which segfaults when called). They
+// report "unavailable" via -1 / no-op.
+#[cfg(not(target_os = "linux"))]
+pub mod async_stubs {
+    pub unsafe extern "C" fn reactor_create() -> i64 {
+        -1
+    }
+    pub unsafe extern "C" fn reactor_add(_e: i64, _f: i64, _ev: i64) -> i64 {
+        -1
+    }
+    pub unsafe extern "C" fn reactor_remove(_e: i64, _f: i64) -> i64 {
+        -1
+    }
+    pub unsafe extern "C" fn reactor_poll(_e: i64, _buf: i64, _max: i64, _t: i64) -> i64 {
+        -1
+    }
+    pub unsafe extern "C" fn reactor_event_fd(_buf: i64, _i: i64) -> i64 {
+        -1
+    }
+    pub unsafe extern "C" fn reactor_event_flags(_buf: i64, _i: i64) -> i64 {
+        0
+    }
+    pub unsafe extern "C" fn reactor_destroy(_e: i64) {}
+    pub unsafe extern "C" fn waker_create() -> i64 {
+        -1
+    }
+    pub unsafe extern "C" fn waker_wake(_f: i64) -> i64 {
+        -1
+    }
+    pub unsafe extern "C" fn waker_consume(_f: i64) -> i64 {
+        -1
+    }
+    pub unsafe extern "C" fn waker_destroy(_f: i64) {}
+    pub unsafe extern "C" fn scheduler_register_waker(_e: i64, _f: i64) -> i64 {
+        -1
+    }
+    pub unsafe extern "C" fn scheduler_run_reactor(_e: i64, _t: i64) -> i64 {
+        -1
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -11,6 +11,7 @@ pub mod fs;
 pub mod host;
 pub mod identity;
 pub mod io;
+pub mod jit_stubs;
 pub mod map;
 pub mod memory;
 pub mod memory_bulletproof;
@@ -19,6 +20,10 @@ pub mod net;
 pub mod option;
 pub mod path;
 pub mod process;
+// The reactor uses Linux-only syscalls (epoll, timerfd). On other platforms
+// the async reactor is unavailable; the Zeta reactor.z source replaces this
+// when self-hosting.
+#[cfg(target_os = "linux")]
 pub mod reactor;
 pub mod std;
 pub mod sync;

--- a/src/runtime/reactor.rs
+++ b/src/runtime/reactor.rs
@@ -333,24 +333,3 @@ pub unsafe extern "C" fn scheduler_run_reactor(epfd: i64, timeout_ms: i64) -> i6
     }
     count
 }
-
-// ── Helpers ──
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn set_nonblocking(fd: i64) -> i64 {
-    let flags = libc::fcntl(fd as i32, libc::F_GETFL, 0);
-    if flags < 0 {
-        return -1;
-    }
-    libc::fcntl(fd as i32, libc::F_SETFL, flags | libc::O_NONBLOCK) as i64
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn monotonic_ns() -> i64 {
-    let mut ts: libc::timespec = std::mem::zeroed();
-    if libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) == 0 {
-        ts.tv_sec * 1_000_000_000 + ts.tv_nsec
-    } else {
-        -1
-    }
-}


### PR DESCRIPTION
## What

Upgrades the bootstrap build stack from **LLVM 21 → LLVM 22** so the compiler builds with current toolchains (Homebrew now ships `llvm@22`, not `llvm@21`), and fixes a set of **pre-existing codegen/runtime bugs** that the new build surfaces (it runs code the old build rejected at validation).

## Commits

1. **`LLVM 21 → 22: bump inkwell/llvm-sys, update CI, port runtime`**
   - `inkwell 0.9.0 (llvm22-1)` + `llvm-sys 221.0.0`
   - bootstrap-branch CI (`ci`/`release`/`benchmarks`): `apt llvm-22`, `LLVM_SYS_221_PREFIX`
   - `wasm-ld-21` → `wasm-ld-22`; inkwell 0.9 API adaptations
   - JIT function mapping rebuilt as tables + a defensive pass that also maps LLVM's `.N`-suffixed declaration variants (duplicates were auto-suffixed and missed by by-name mapping → NULL externs)
   - Linux-gated reactor/wakers; new `src/runtime/jit_stubs.rs`

2. **`Fix codegen/runtime bugs surfaced by the LLVM 22 build`** — all pre-existing on the bootstrap tip:
   - **Duplicate std declarations** (`codegen.rs`): the prelude declared 9 runtime symbols twice with conflicting arities (e.g. `array_new` 2-arg vs the 1-arg real impl). LLVM auto-suffixes duplicates (`array_new.10`); call sites bound to the numbered copy, which the JIT never maps → NULL → segfault. Now a single canonical declaration set.
   - **`str_*` method resolution** (`codegen.rs`): MIR names method calls with an overload suffix (`str_trim_1`); the `host_` mapping ran on the suffixed name → non-existent `host_str_trim_1` → NULL. New `host_candidate_for()` strips the trailing `_<digits>` first (also fixes `len_str_2` → `host_str_len`).
   - **Neutered `array_new`** (`array.rs`): returned `0x0BADF00D` + a debug print since v0.3.88 (stale autonomous-agent landmine); the real implementation (header + data alloc, canary, 0xCD fill) is restored.
   - **Array-like method dispatch** (`gen.rs`): `push`/`append`/`len`/`count`/`get`/`set` only handled `DynamicArray` receivers; `[u8]` slices and annotated arrays fell through to an unmapped bare name. Now covers `Array | Slice | DynamicArray`.
   - **`use` of inline modules** (`resolver.rs`): `use math::add;` for an inline `mod math` failed file resolution (W2002), leaving unqualified calls bound to a dead extern while the real body sat registered as `math::add`. The registered `module::item` is now aliased under the plain import name (same treatment file imports get). Works when the `mod` precedes the `use` (single-pass registration — noted in a comment).

## Validation

Full `.z` suite A/B — this branch vs the shipped May 8 prebuilt binary (`bin/zetac-macos-arm64`), 477-file bootstrap suite, 30 s per-file timeout:

| | PASS | NOMAIN | ERR | CRASH | HANG |
|---|---|---|---|---|---|
| May prebuilt (LLVM 21) | 240 | 101 | 98 | 37 | 1 |
| This PR (LLVM 22) | **314** | 101 | **23** | 35 | 3 |

Main-branch 785-file suite: PASS 492 → 501, CRASH 94 → 85.

`cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets`: 0 warnings ✓ · `cargo test`: 114/114 ✓
Builds on macOS arm64 with Homebrew `llvm@22` (`LLVM_SYS_221_PREFIX=/opt/homebrew/opt/llvm@22`).

## Known pre-existing issues (not caused by, nor fixed in, this PR)

- **`[dynamic]` non-i64 index-access cluster** (~16 sieve/murphy/benchmark files, e.g. `tests/primezeta/test_sieve.z`): index access on `[dynamic]u8`-style arrays lowers to raw `getelementptr i64` loads/stores (wrong element width, no bounds check), and `array_push` does not grow a full array. These files previously never ran (validation rejected the `array_new` call, which is why they were ERR before); now they execute and read/write out of bounds — non-deterministic garbage results, occasional crash/hang depending on heap layout. Suggests a follow-up PR: lower index access through `array_get`/`array_set` using the declared element width, and make `array_push` grow.
- **`||` parser regression**: a function whose body contains `||` (e.g. `a && b || !a`) is silently dropped from the file (`No main function found. Available: []`); the same file works on the May binary. Tip parser issue; follow-up PR.
- **Pre-existing crash set** (21 files): crash identically on the May binary (spot-checked — same signal and first diagnostic on both builds).
- **Self-host**: `zeta_src/main.z` hits E4001 on both the May binary and this build (a raw string containing `fn main` derails parsing) — pre-existing.
- **AOT linking** needs `zeta_runtime_c.o` in the working directory (missing in a fresh checkout) — pre-existing; JIT execution is unaffected.

## Follow-up (separate PR — a PR can only target one branch)

Main-branch workflows (`ci`, `build-macos`, `build-binaries`, `release`, `benchmarks`) all check out `bootstrap` and install LLVM 21; once this merges they need the same 21 → 22 bump. Related: main-branch `build-macos.yml` has been failing silently since the May 8 reactor merge (stale `bin/` artifacts persist, and `bin/zetac-macos-x64` is actually a Linux ELF).
